### PR TITLE
Fix Skip

### DIFF
--- a/LavaNode.cs
+++ b/LavaNode.cs
@@ -396,7 +396,8 @@ namespace Victoria
         {
             _lavalink.LogDebug("Received track update.");
             if (!_players.TryGetValue(guildId, out var old)) return;
-            old.CurrentTrack = track;
+            if (reason != TrackReason.Replaced)
+                old.CurrentTrack = default;
             _players.TryUpdate(guildId, old, old);
             Finished?.Invoke(old, track, reason);
         }

--- a/LavaPlayer.cs
+++ b/LavaPlayer.cs
@@ -122,7 +122,7 @@ namespace Victoria
                 Stop();
                 throw new InvalidOperationException("Queue was empty. Played has been stopped.");
             }
-
+            
             Play(track);
             return track;
         }

--- a/LavaPlayer.cs
+++ b/LavaPlayer.cs
@@ -123,7 +123,8 @@ namespace Victoria
                 throw new InvalidOperationException("Queue was empty. Played has been stopped.");
             }
 
-            Stop();
+            //var result = (CurrentTrack, track);
+            //Stop();
             Play(track);
             return track;
         }

--- a/LavaPlayer.cs
+++ b/LavaPlayer.cs
@@ -123,8 +123,6 @@ namespace Victoria
                 throw new InvalidOperationException("Queue was empty. Played has been stopped.");
             }
 
-            //var result = (CurrentTrack, track);
-            //Stop();
             Play(track);
             return track;
         }


### PR DESCRIPTION
This fixes the skip. It takes a second or two to skip the track but seems to be working correctly now. 

i tried using stop before play but that seems to keep the currenttrack at null and break the entire thing. I dont know why that happens but it does...

![](https://media.discordapp.net/attachments/508369825958199307/510565380134010891/unknown.png?width=628&height=519)