### PR TITLE
[ BUG ] SetVolumeAsync after SkipAsync (can) throw(s) InvalidOperationException #32

### DIFF
--- a/LavaBaseClient.cs
+++ b/LavaBaseClient.cs
@@ -252,9 +252,11 @@ namespace Victoria
                     {
                         case EventType.TrackEnd:
                             var endReason = json.GetValue("reason").ToObject<TrackEndReason>();
-                            player.IsPlaying = false;
                             if (endReason != TrackEndReason.Replaced)
+                            {
+                                player.IsPlaying = false;
                                 player.CurrentTrack = default;
+                            }
                             OnTrackFinished?.Invoke(player, track, endReason);
                             break;
 


### PR DESCRIPTION
Fix IsPlaying getting set to false on skip.

Issue:
https://github.com/Yucked/Victoria/issues/32