### PR TITLE
IsPlaying check in SetVolumeAsync is unnecessary

### DIFF
--- a/LavaPlayer.cs
+++ b/LavaPlayer.cs
@@ -186,9 +186,6 @@ namespace Victoria
         /// <param name="volume">Volume may range from 0 to 1000. 100 is default.</param>
         public Task SetVolumeAsync(int volume)
         {
-            if (!IsPlaying)
-                throw new InvalidOperationException(InvalidOp);
-
             if (volume > 1000)
                 throw new ArgumentOutOfRangeException($"{nameof(volume)} was greater than max limit which is 1000.");
 


### PR DESCRIPTION
I tried to remove the IsPlaying check in SetVolumeAsync and use the method right after joining a VoiceChannel - and it works perfectly.
So the IsPlaying check is useless, I can't see any reason for the check.

It should be removed so the user can set the volume before starting a sound (because the default volume of 100 can be pretty loud).