### PR TITLE
Add a provider property to LavaTrack objets

### DIFF
--- a/Entities/Responses/LavaTrack.cs
+++ b/Entities/Responses/LavaTrack.cs
@@ -44,6 +44,12 @@ namespace Victoria.Entities
         [JsonProperty("uri")]
         public Uri Uri { get; internal set; }
 
+        [JsonIgnore]
+        public string Provider
+        {
+            get => this.Uri.ToString().GetUrlProvider();
+        }
+
         /// <summary>
         /// 
         /// </summary>

--- a/VictoriaExtensions.cs
+++ b/VictoriaExtensions.cs
@@ -77,6 +77,22 @@ namespace Victoria
         }
 
         /// <summary>
+        /// Gets the provider name for an url (example: google.com -> google)
+        /// </summary>
+        /// <param name="url">The url to get the provider from</param>
+        /// <returns>The provider name</returns>
+        public static string GetUrlProvider(this string url)
+        {
+            Regex regex = Compiled(@"https?:\/\/([^\/\s]+)\.");
+            Match match = regex.Match(url);
+            if (match == null)
+                return "N/A";
+
+            string[] domainParts = match.Groups[2].Value.Split('.');
+            return domainParts[domainParts.Length - 1];
+        }
+
+        /// <summary>
         /// Checks if the <see cref="TrackEndReason"/> is Finished or LoadFailed.
         /// </summary>
         /// <param name="reason"><see cref="TrackEndReason"/></param>


### PR DESCRIPTION
This would be especially useful when processing is depending on a specific source (youtube, soundcloud etc...)