### PR TITLE
Unsealed LavaTrack for easy custom implementations / extensions of LavaTrack

### DIFF
--- a/Entities/Responses/LavaTrack.cs
+++ b/Entities/Responses/LavaTrack.cs
@@ -4,7 +4,7 @@ using Victoria.Queue;
 
 namespace Victoria.Entities
 {
-    public sealed class LavaTrack : IQueueObject
+    public class LavaTrack : IQueueObject
     {
         [JsonIgnore]
         internal string Hash { get; set; }


### PR DESCRIPTION
I have unsealed `LavaTrack`, meaning it can be inherited as a base class.
This solution will help in bots that add more functionality to their track system, but yet still want to work with the same type (LavaTrack) for Victoria / Lavalink operations.
I am aware of the `IQueueObject` interface that is public, but inheriting from LavaTrack can allow creating a custom track implementation and using it fluently with the Lavalink operations as if it's a normal track

Note: These changes are not big, and I did not elaborate in my explanation of why this feature is needed. If you have doubts, feel free to leave a question in the comments.