### PR TITLE
Reduce memory usage.

### DIFF
--- a/Victoria.Lavalink/Decoder/TrackDecoder.cs
+++ b/Victoria.Lavalink/Decoder/TrackDecoder.cs
@@ -1,5 +1,6 @@
 ﻿using System;
-using System.IO;
+using System.Text;
+using System.Buffers.Text;
 
 namespace Victoria.Lavalink.Decoder
 {
@@ -16,10 +17,10 @@ namespace Victoria.Lavalink.Decoder
         /// </returns>
         public static LavaTrack Decode(string hash)
         {
-            var bytes = Convert.FromBase64String(hash);
-
-            using var memStream = new MemoryStream(bytes);
-            using var javaReader = new JavaBinaryReader(memStream);
+            Span<byte> hashBuffer = stackalloc byte[hash.Length];
+            Encoding.ASCII.GetBytes(hash, hashBuffer);
+            Base64.DecodeFromUtf8InPlace(hashBuffer, out int bytesWritten);
+            var javaReader = new JavaBinaryReader(hashBuffer.Slice(bytesWritten));
 
             // Reading header
             var header = javaReader.Read<int>();

--- a/Victoria.Lavalink/Decoder/TrackDecoder.cs
+++ b/Victoria.Lavalink/Decoder/TrackDecoder.cs
@@ -20,7 +20,7 @@ namespace Victoria.Lavalink.Decoder
             Span<byte> hashBuffer = stackalloc byte[hash.Length];
             Encoding.ASCII.GetBytes(hash, hashBuffer);
             Base64.DecodeFromUtf8InPlace(hashBuffer, out int bytesWritten);
-            var javaReader = new JavaBinaryReader(hashBuffer.Slice(bytesWritten));
+            var javaReader = new JavaBinaryReader(hashBuffer.Slice(0, bytesWritten));
 
             // Reading header
             var header = javaReader.Read<int>();


### PR DESCRIPTION
Use Base64.DecodeFromUtf8InPlace instead of Convert.FromBase64String to avoid allocating a new byte array.

Make JavaBinaryReader a ref struct to avoid allocating a new MemoryStream and JavaBinaryReader object everytime a track is decoded.

This way the only allocations will be the new LavaTrack object and strings (title, author, id, and url).