### PR TITLE
Update player voice channel on user move.

### DIFF
--- a/src/LavaNode.cs
+++ b/src/LavaNode.cs
@@ -373,6 +373,7 @@ namespace Victoria
                 return Task.CompletedTask;
 
             player.VoiceState = newState;
+            player.VoiceChannel = newState.VoiceChannel;
 
             return Task.CompletedTask;
         }

--- a/src/LavaPlayer.cs
+++ b/src/LavaPlayer.cs
@@ -46,7 +46,7 @@ namespace Victoria
         /// <summary>
         ///     Voice channel this player is connected to.
         /// </summary>
-        public IVoiceChannel VoiceChannel { get; private set; }
+        public IVoiceChannel VoiceChannel { get; internal set; }
 
         /// <summary>
         ///     Channel bound to this player.


### PR DESCRIPTION
When a user moves the bot via drag/drop. The players voice channel was never updated. 
This should resolve this issue.

Note: This should also update the player voice channel when you move using LavaNode#MoveAsync