### PR TITLE
Defined ignore attributes on optional properties

### DIFF
--- a/src/Filters/EqualizerBand.cs
+++ b/src/Filters/EqualizerBand.cs
@@ -19,7 +19,7 @@ namespace Victoria.Filters {
         ///     Gain is the multiplier for the given band. The default value is 0. Valid values range from -0.25 to 1.0,
         ///     where -0.25 means the given band is completely muted, and 0.25 means it is doubled.
         /// </summary>
-        [JsonPropertyName("gain")]
+        [JsonPropertyName("gain"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public double Gain { get; }
 
         /// <summary>

--- a/src/Payloads/Player/PlayPayload.cs
+++ b/src/Payloads/Player/PlayPayload.cs
@@ -5,19 +5,19 @@ namespace Victoria.Payloads.Player {
         [JsonPropertyName("track")]
         public string Hash { get; }
 
-        [JsonPropertyName("noReplace")]
+        [JsonPropertyName("noReplace"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public bool NoReplace { get; }
 
-        [JsonPropertyName("startTime")]
+        [JsonPropertyName("startTime"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public int StartTime { get; }
 
-        [JsonPropertyName("endTime")]
+        [JsonPropertyName("endTime"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public int EndTime { get; }
 
-        [JsonPropertyName("volume")]
+        [JsonPropertyName("volume"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public int Volume { get; }
 
-        [JsonPropertyName("pause")]
+        [JsonPropertyName("pause"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public bool Pause { get; }
 
         public PlayPayload(ulong guildId, PlayArgs playArgs)


### PR DESCRIPTION
Hi

There are some optional properties in a couple of payloads (mostly the "PlayPayload"), that are being needlessly sent to Lavalink (after commit cf23ef7acf5b362d0d21adf6fba9630813b5d26d set the JSON serialization options to ignore only null values) when they have their default value set, so I added some "JsonIgnoreAttributes" to those properties (I don't think I left out any), to have them not be serialized if their default value is set.

Maybe there's a better way to achieve this, but I thought I'd start this pull request anyway, just in case you're fine with the idea.

P.S. Thank you for creating this wonderful Lavalink client.