### PR TITLE
Removes Buffer Size from config, Append to list until EOM

### DIFF
--- a/src/Node/NodeConfiguration.cs
+++ b/src/Node/NodeConfiguration.cs
@@ -64,7 +64,6 @@ namespace Victoria.Node {
             = new() {
                 ReconnectAttempts = 10,
                 ReconnectDelay = TimeSpan.FromSeconds(3),
-                BufferSize = 512
             };
 
         internal string HttpEndpoint

--- a/src/WebSocket/WebSocketClient.cs
+++ b/src/WebSocket/WebSocketClient.cs
@@ -199,11 +199,12 @@ namespace Victoria.WebSocket {
 
                 do {
                     var receiveResult = await _webSocket.ReceiveAsync(buffer, _connectionTokenSource.Token);
-                    await memoryStream.WriteAsync(buffer.AsMemory()[receiveResult.Count..]);
                     
                     if(!receiveResult.EndOfMessage) {
+                        await memoryStream.WriteAsync(buffer);
                         continue;
                     }
+                    await memoryStream.WriteAsync(buffer.AsMemory(0, receiveResult.Count));
 
                     switch (receiveResult.MessageType) {
                         case WebSocketMessageType.Text:

--- a/src/WebSocket/WebSocketClient.cs
+++ b/src/WebSocket/WebSocketClient.cs
@@ -208,11 +208,13 @@ namespace Victoria.WebSocket {
                     switch (receiveResult.MessageType) {
                         case WebSocketMessageType.Text:
                             await OnDataAsync.Invoke(new DataEventArgs(message.ToArray()));
+                            message.Clear();
                             break;
 
                         case WebSocketMessageType.Close:
                             await DisconnectAsync();
                             await ReconnectAsync();
+                            message.Clear();
                             break;
                     }
                 } while (_webSocket.State == WebSocketState.Open &&

--- a/src/WebSocket/WebSocketConfiguration.cs
+++ b/src/WebSocket/WebSocketConfiguration.cs
@@ -1,16 +1,10 @@
-﻿using System;
+using System;
 
 namespace Victoria.WebSocket {
     /// <summary>
     /// 
     /// </summary>
     public sealed class WebSocketConfiguration {
-        /// <summary>
-        ///     Max buffer size for receiving websocket message.
-        /// </summary>
-        public ushort BufferSize { get; set; }
-            = 512;
-
         /// <summary>
         ///     How many reconnect attempts are allowed.
         /// </summary>


### PR DESCRIPTION
Should be much better, won't depend on needing a set buffer size, need to remove trailing nulls, or do weird trickery with the `finalBuffer`

Tested it out on my bot and it seems to work.