### PR TITLE
Fix lavalink filters

### DIFF
--- a/src/Payloads/Player/FilterPayload.cs
+++ b/src/Payloads/Player/FilterPayload.cs
@@ -4,34 +4,34 @@ using Victoria.Player.Filters;
 
 namespace Victoria.Payloads.Player {
     internal sealed class FilterPayload : AbstractPlayerPayload {
-        [JsonPropertyName("volume")]
+        [JsonPropertyName("volume"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public double Volume { get; }
 
-        [JsonPropertyName("equalizer")]
+        [JsonPropertyName("equalizer"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public IEnumerable<EqualizerBand> Bands { get; }
 
-        [JsonPropertyName("karoke")]
+        [JsonPropertyName("karoke"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public KarokeFilter Karoke { get; set; }
 
-        [JsonPropertyName("timescale")]
+        [JsonPropertyName("timescale"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public TimescaleFilter Timescale { get; set; }
 
-        [JsonPropertyName("tremolo")]
+        [JsonPropertyName("tremolo"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public TremoloFilter Tremolo { get; set; }
 
-        [JsonPropertyName("vibrato")]
+        [JsonPropertyName("vibrato"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public VibratoFilter Vibrato { get; set; }
 
-        [JsonPropertyName("rotation")]
+        [JsonPropertyName("rotation"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public RotationFilter Rotation { get; set; }
 
-        [JsonPropertyName("distortion")]
+        [JsonPropertyName("distortion"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public DistortionFilter Distortion { get; set; }
 
-        [JsonPropertyName("channelMix")]
+        [JsonPropertyName("channelMix"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public ChannelMixFilter ChannelMix { get; set; }
 
-        [JsonPropertyName("lowPass")]
+        [JsonPropertyName("lowPass"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public LowPassFilter LowPass { get; set; }
 
         public FilterPayload(ulong guildId, IFilter filter, double volume, IEnumerable<EqualizerBand> bands)

--- a/src/Player/Filters/DistortionFilter.cs
+++ b/src/Player/Filters/DistortionFilter.cs
@@ -9,48 +9,48 @@ namespace Victoria.Player.Filters {
         /// 
         /// </summary>
         [JsonPropertyName("sinOffset")]
-        public int SinOffset { get; set; }
+        public double SinOffset { get; set; }
 
         /// <summary>
         /// 
         /// </summary>
         [JsonPropertyName("sinScale")]
-        public int SinScale { get; set; }
+        public double SinScale { get; set; }
 
         /// <summary>
         /// 
         /// </summary>
         [JsonPropertyName("cosOffset")]
-        public int CosOffset { get; set; }
+        public double CosOffset { get; set; }
 
         /// <summary>
         /// 
         /// </summary>
         [JsonPropertyName("cosScale")]
-        public int CosScale { get; set; }
+        public double CosScale { get; set; }
 
         /// <summary>
         /// 
         /// </summary>
         [JsonPropertyName("tanOffset")]
-        public int TanOffset { get; set; }
+        public double TanOffset { get; set; }
 
         /// <summary>
         /// 
         /// </summary>
         [JsonPropertyName("tanScale")]
-        public int TanScale { get; set; }
+        public double TanScale { get; set; }
 
         /// <summary>
         /// 
         /// </summary>
         [JsonPropertyName("offset")]
-        public int Offset { get; set; }
+        public double Offset { get; set; }
 
         /// <summary>
         /// 
         /// </summary>
         [JsonPropertyName("scale")]
-        public int Scale { get; set; }
+        public double Scale { get; set; }
     }
 }


### PR DESCRIPTION
In v6, attempting to add filters would cause the track to suddenly end. `DistortionFilter`'s properties were integers, while LavaLink's distortion filters accepted floats

### Changes
- Re-added `FilterPayload`'s `JsonIgnore` properties from v5
- Changed `DistortionFilter`'s `int`s to `double`s, like the rest of the filters