### PR TITLE
Fix build badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 		<img src="https://img.shields.io/badge/Discord-Support-%237289DA.svg?logo=discord&style=for-the-badge&logoWidth=30&labelColor=0d0d0d" />
 	</a>
 	<a href="https://github.com/Yucked/Victoria/actions">
-		<img src="https://img.shields.io/github/workflow/status/Yucked/Victoria/.NET%20Core%20Workflow?label=BUILD%20STATUS&logo=github&style=for-the-badge&logoWidth=30&color=181717" />
+		<img src="https://img.shields.io/github/actions/workflow/status/Yucked/Victoria/dotnet-core.yml?label=BUILD%20STATUS&logo=github&style=for-the-badge&logoWidth=30&color=181717" />
 	</a>
 	<a href="https://www.nuget.org/packages/Victoria/">
 		<img src="https://img.shields.io/nuget/dt/Victoria.svg?label=Downloads&logo=nuget&style=for-the-badge&logoWidth=30&labelColor=0d0d0d" />


### PR DESCRIPTION
They changed how these are handled so the URL is slightly different now. I just followed their documentation to fix it.

For reference:
https://github.com/badges/shields/issues/8671