### PR TITLE
Bug/stop async nullable track

### DIFF
--- a/src/LavaPlayerExtensions.cs
+++ b/src/LavaPlayerExtensions.cs
@@ -86,7 +86,7 @@ public static class LavaPlayerExtensions {
             lavaPlayer.GuildId,
             noReplace,
             updatePayload: new UpdatePlayerPayload(
-                EncodedTrack: lavaTrack.Hash,
+                EncodedTrack: lavaTrack == null ? null : lavaTrack.Hash,
                 IsPaused: shouldPause));
     }
 

--- a/src/LavaPlayerExtensions.cs
+++ b/src/LavaPlayerExtensions.cs
@@ -76,13 +76,18 @@ public static class LavaPlayerExtensions {
     /// </summary>
     /// <exception cref="NotImplementedException"></exception>
     public static async ValueTask StopAsync<TLavaPlayer, TLavaTrack>(this LavaPlayer<TLavaTrack> lavaPlayer,
-                                                                     LavaNode<TLavaPlayer, TLavaTrack> lavaNode)
+                                                                     LavaNode<TLavaPlayer, TLavaTrack> lavaNode,
+                                                                     TLavaTrack lavaTrack,
+                                                                     bool noReplace = false,
+                                                                     bool shouldPause = true)
         where TLavaTrack : LavaTrack
         where TLavaPlayer : LavaPlayer<TLavaTrack> {
         await lavaNode.UpdatePlayerAsync(
             lavaPlayer.GuildId,
+            noReplace,
             updatePayload: new UpdatePlayerPayload(
-                EncodedTrack: null));
+                EncodedTrack: lavaTrack.Hash,
+                IsPaused: shouldPause));
     }
 
     /// <summary>
@@ -105,17 +110,23 @@ public static class LavaPlayerExtensions {
     /// <summary>
     /// 
     /// </summary>
-    /// <param name="lavaPlayer"></param>
-    /// <param name="lavaNode"></param>
     /// <typeparam name="TLavaPlayer"></typeparam>
     /// <typeparam name="TLavaTrack"></typeparam>
+    /// <param name="lavaPlayer"></param>
+    /// <param name="lavaNode"></param>
+    /// <param name="noReplace"></param>
+    /// <returns></returns>
     public static async ValueTask ResumeAsync<TLavaPlayer, TLavaTrack>(this LavaPlayer<TLavaTrack> lavaPlayer,
-                                                                       LavaNode<TLavaPlayer, TLavaTrack> lavaNode)
+                                                                       LavaNode<TLavaPlayer, TLavaTrack> lavaNode,
+                                                                       TLavaTrack lavaTrack,
+                                                                       bool noReplace = false)
         where TLavaTrack : LavaTrack
         where TLavaPlayer : LavaPlayer<TLavaTrack> {
         await lavaNode.UpdatePlayerAsync(
             lavaPlayer.GuildId,
+            noReplace,
             updatePayload: new UpdatePlayerPayload(
+                EncodedTrack: lavaTrack.Hash,
                 IsPaused: false));
     }
 

--- a/src/LavaPlayerExtensions.cs
+++ b/src/LavaPlayerExtensions.cs
@@ -118,13 +118,12 @@ public static class LavaPlayerExtensions {
     /// <returns></returns>
     public static async ValueTask ResumeAsync<TLavaPlayer, TLavaTrack>(this LavaPlayer<TLavaTrack> lavaPlayer,
                                                                        LavaNode<TLavaPlayer, TLavaTrack> lavaNode,
-                                                                       TLavaTrack lavaTrack,
-                                                                       bool noReplace = false)
+                                                                       TLavaTrack lavaTrack)
         where TLavaTrack : LavaTrack
-        where TLavaPlayer : LavaPlayer<TLavaTrack> {
+        where TLavaPlayer : LavaPlayer<TLavaTrack>
+    {
         await lavaNode.UpdatePlayerAsync(
             lavaPlayer.GuildId,
-            noReplace,
             updatePayload: new UpdatePlayerPayload(
                 EncodedTrack: lavaTrack.Hash,
                 IsPaused: false));


### PR DESCRIPTION
- Default the stop behavior to pause the track immediately and replace
- Allow null to be passed for the encoded track for StopAsync.  Per LavaLink API, null stops the current track.  If not null, use the hash
- Fix resume to work.  Before was null and stopped the track