### PR TITLE
Fix SearchResponse constructor

### DIFF
--- a/src/Converters/LavaTrackConverter.cs
+++ b/src/Converters/LavaTrackConverter.cs
@@ -10,9 +10,11 @@ internal sealed class LavaTrackConverter : JsonConverter<LavaTrack> {
         {
             trackDocument.RootElement.TryGetProperty("encoded", out JsonElement trackHashElement);
             trackDocument.RootElement.TryGetProperty("info", out JsonElement trackElement);
+            trackDocument.RootElement.TryGetProperty("pluginInfo", out JsonElement trackPluginInfoElement);
 
             LavaTrack track = JsonSerializer.Deserialize<LavaTrack>(trackElement);
             track.Hash = trackHashElement.ToString();
+            track.PluginInfo = trackPluginInfoElement.ToString();
 
             return track;
         }

--- a/src/Converters/LavaTrackListConverter.cs
+++ b/src/Converters/LavaTrackListConverter.cs
@@ -15,7 +15,7 @@ internal sealed class LavaTrackListConverter : JsonConverter<IReadOnlyCollection
             List<LavaTrack> trackList = new List<LavaTrack>();
             foreach (JsonElement element in trackDocument.RootElement.EnumerateArray())
             {
-                trackList.Add(JsonSerializer.Deserialize<LavaTrack>(element, new JsonSerializerOptions() { Converters = { new LavaTrackConverter() } }));
+                trackList.Add(JsonSerializer.Deserialize<LavaTrack>(element, Extensions.Options));
             }
 
             return new ReadOnlyCollection<LavaTrack>(trackList);

--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -6,14 +6,19 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
+using Victoria.Converters;
 
 namespace Victoria {
     /// <summary>
     /// 
     /// </summary>
     public static class Extensions {
-        private static readonly JsonSerializerOptions Options = new() {
-            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault
+        internal static readonly JsonSerializerOptions Options = new() {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
+            Converters = {
+                new LavaTrackConverter(),
+                new LavaTrackListConverter(),
+            }
         };
 
         /// <summary>

--- a/src/LavaNode.cs
+++ b/src/LavaNode.cs
@@ -85,13 +85,6 @@ public class LavaNode<TLavaPlayer, TLavaTrack> : IAsyncDisposable
     private readonly ILogger<LavaNode<TLavaPlayer, TLavaTrack>> _logger;
     private readonly ConcurrentDictionary<ulong, VoiceState> _voiceStates;
 
-    private static readonly JsonSerializerOptions TrackConverterOptions = new() {
-        Converters = {
-            new LavaTrackConverter(),
-            new LavaTrackListConverter(),
-        }
-    };
-
     /// <summary>
     /// 
     /// </summary>
@@ -312,7 +305,7 @@ public class LavaNode<TLavaPlayer, TLavaTrack> : IAsyncDisposable
         var responseMessage = await _httpClient.GetAsync($"/{_version}/decodetrack?encodedTrack={HttpUtility.UrlEncode(trackHash)}");
         await using var stream = await responseMessage.Content.ReadAsStreamAsync();
         RestException.ThrowIfNot200(responseMessage.IsSuccessStatusCode, stream);
-        return await JsonSerializer.DeserializeAsync<TLavaTrack>(stream, TrackConverterOptions);
+        return await JsonSerializer.DeserializeAsync<TLavaTrack>(stream, Extensions.Options);
     }
 
     /// <summary>
@@ -326,7 +319,7 @@ public class LavaNode<TLavaPlayer, TLavaTrack> : IAsyncDisposable
             new ReadOnlyMemoryContent(JsonSerializer.SerializeToUtf8Bytes(tracksHashes)));
         await using var stream = await responseMessage.Content.ReadAsStreamAsync();
         RestException.ThrowIfNot200(responseMessage.IsSuccessStatusCode, stream);
-        return await JsonSerializer.DeserializeAsync<IReadOnlyCollection<TLavaTrack>>(stream, TrackConverterOptions);
+        return await JsonSerializer.DeserializeAsync<IReadOnlyCollection<TLavaTrack>>(stream, Extensions.Options);
     }
 
     /// <summary>

--- a/src/Rest/Search/SearchException.cs
+++ b/src/Rest/Search/SearchException.cs
@@ -17,5 +17,11 @@ namespace Victoria.Rest.Search {
         /// </summary>
         [JsonPropertyName("severity"), JsonInclude]
         public string Severity { get; private set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonPropertyName("cause"), JsonInclude]
+        public string Cause { get; private set; }
     }
 }

--- a/src/Rest/Search/SearchResponse.cs
+++ b/src/Rest/Search/SearchResponse.cs
@@ -10,13 +10,6 @@ namespace Victoria.Rest.Search {
     /// 
     /// </summary>
     public sealed class SearchResponse {
-        private static readonly JsonSerializerOptions TrackConverterOptions = new()
-        {
-            Converters = {
-            new LavaTrackConverter(),
-            new LavaTrackListConverter(),
-        }
-        };
         /// <summary>
         /// 
         /// </summary>
@@ -51,15 +44,15 @@ namespace Victoria.Rest.Search {
             switch (Type)
             {
                 case SearchType.Track:
-                    LavaTrack track = JsonSerializer.Deserialize<LavaTrack>(dataElement, TrackConverterOptions);
+                    LavaTrack track = JsonSerializer.Deserialize<LavaTrack>(dataElement, Extensions.Options);
                     Tracks = [track];
                     break;
                 case SearchType.Playlist:
                     Exception = JsonSerializer.Deserialize<SearchException>(dataElement.GetProperty("info"));
-                    Tracks = JsonSerializer.Deserialize<IReadOnlyCollection<LavaTrack>>(dataElement.GetProperty("tracks"), TrackConverterOptions);
+                    Tracks = JsonSerializer.Deserialize<IReadOnlyCollection<LavaTrack>>(dataElement.GetProperty("tracks"), Extensions.Options);
                     break;
                 case SearchType.Search:
-                    Tracks = JsonSerializer.Deserialize<IReadOnlyCollection<LavaTrack>>(dataElement, TrackConverterOptions);
+                    Tracks = JsonSerializer.Deserialize<IReadOnlyCollection<LavaTrack>>(dataElement, Extensions.Options);
                     break;
                 case SearchType.Error:
                     Exception = JsonSerializer.Deserialize<SearchException>(dataElement);


### PR DESCRIPTION
- Added `PluginInfo` deserializing in `LavaTrackConverter`
- Fixed playlist-, search- and exception-result deserializing in `SearchResponse` constructor, adjusted track-result deserializing to use LavaTrackConverter