### PR TITLE
Fix VoiceStates not updating when event is fired

### DIFF
--- a/src/LavaNode.cs
+++ b/src/LavaNode.cs
@@ -583,7 +583,7 @@ public class LavaNode<TLavaPlayer, TLavaTrack> : IAsyncDisposable
         }
 
         voiceState.SessionId = sessionId;
-        _voiceStates.AddOrUpdate(guildId, voiceState, (_, _) => default);
+        _voiceStates.AddOrUpdate(guildId, voiceState, (_, _) => voiceState);
 
         if (!string.IsNullOrWhiteSpace(voiceState.Token)) {
             return UpdatePlayerAsync(guildId,
@@ -599,9 +599,7 @@ public class LavaNode<TLavaPlayer, TLavaTrack> : IAsyncDisposable
         }
 
         voiceState = new VoiceState(voiceServer.Token, voiceServer.Endpoint, voiceState.SessionId);
-        _voiceStates.AddOrUpdate(voiceServer.Guild.Id,
-            voiceState,
-            (_, _) => default);
+        _voiceStates.AddOrUpdate(voiceServer.Guild.Id, voiceState, (_, _) => voiceState);
 
         if (!string.IsNullOrWhiteSpace(voiceState.SessionId)) {
             return UpdatePlayerAsync(voiceServer.Guild.Id,


### PR DESCRIPTION
AddOrUpdate was wrongly used, hence not update when event was fired. Voice state not being updated if the bot left the voice channel and tried to join again, SessionId will NEVER be the right one and Lavalink would be enable to play anything