### PR TITLE
Fix player not able to play music again when the bot had already disconnected once

### DIFF
--- a/src/LavaNode.cs
+++ b/src/LavaNode.cs
@@ -569,8 +569,8 @@ public class LavaNode<TLavaPlayer, TLavaTrack> : IAsyncDisposable
     }
 
     private Task OnUserVoiceStateUpdatedAsync(SocketUser user,
-                                              SocketVoiceState currentState,
-                                              SocketVoiceState pastState) {
+                                              SocketVoiceState pastState,
+                                              SocketVoiceState currentState) {
         if (_baseSocketClient.CurrentUser?.Id != user.Id) {
             return Task.CompletedTask;
         }
@@ -585,7 +585,7 @@ public class LavaNode<TLavaPlayer, TLavaTrack> : IAsyncDisposable
         voiceState.SessionId = sessionId;
         _voiceStates.AddOrUpdate(guildId, voiceState, (_, _) => voiceState);
 
-        if (!string.IsNullOrWhiteSpace(voiceState.Token)) {
+        if (!string.IsNullOrWhiteSpace(voiceState.Token) && currentState.VoiceChannel is not null) {
             return UpdatePlayerAsync(guildId,
                 updatePayload: new UpdatePlayerPayload(VoiceState: voiceState));
         }


### PR DESCRIPTION
Problem came from the method that handle update of voice state.

Whenever the bot is done playing music, LeaveAsync make the bot disconnect and DestroyPlayerAsync right away, problem is that the event OnUserVoiceStateUpdatedAsync is triggered with CurrentState.VoiceChannel set to null and a dofferent VoiceSessionId
calling UpdatePlayerAsync and recreating a player in the process.

When the bot come back again, player is not null and create problem.

this PR fix OnUserVoiceStateUpdatedAsync mixed up parameters, and ignore when new channel of the bot is null because player is already destroyed.