### PR TITLE
A toggle for clearing the queue after the bot has left the channel

### DIFF
--- a/src/Configuration.cs
+++ b/src/Configuration.cs
@@ -55,12 +55,6 @@ public record Configuration {
         = true;
 
     /// <summary>
-    ///     Whether to preserve the queue of a guild after the bot has left the channel (note that the queue will only be preserved until lavalink is restarted).
-    /// </summary>
-    public bool PreserveQueue { get; set; }
-        = false;
-
-    /// <summary>
     /// 
     /// </summary>
     public WebSocketConfiguration SocketConfiguration { get; set; }

--- a/src/Configuration.cs
+++ b/src/Configuration.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Victoria.WebSocket.Internal;
 
 namespace Victoria;
@@ -53,6 +53,12 @@ public record Configuration {
     /// </summary>
     public bool SelfDeaf { get; set; }
         = true;
+
+    /// <summary>
+    ///     Whether to preserve the queue of a guild after the bot has left the channel (note that the queue will only be preserved until lavalink is restarted).
+    /// </summary>
+    public bool PreserveQueue { get; set; }
+        = false;
 
     /// <summary>
     /// 

--- a/src/LavaNode.cs
+++ b/src/LavaNode.cs
@@ -222,10 +222,7 @@ public class LavaNode<TLavaPlayer, TLavaTrack> : IAsyncDisposable
         ArgumentNullException.ThrowIfNull(voiceChannel);
         await voiceChannel.DisconnectAsync()
             .ConfigureAwait(false);
-
-        if (!this._configuration.PreserveQueue)
-            (GetPlayerAsync(voiceChannel.GuildId).Result as LavaPlayer<LavaTrack>).GetQueue().Clear();
-
+        LavaPlayerExtensions.Queue?.TryRemove(voiceChannel.GuildId, out _);
         await DestroyPlayerAsync(voiceChannel.GuildId);
     }
     

--- a/src/LavaNode.cs
+++ b/src/LavaNode.cs
@@ -222,6 +222,10 @@ public class LavaNode<TLavaPlayer, TLavaTrack> : IAsyncDisposable
         ArgumentNullException.ThrowIfNull(voiceChannel);
         await voiceChannel.DisconnectAsync()
             .ConfigureAwait(false);
+
+        if (!this._configuration.PreserveQueue)
+            (GetPlayerAsync(voiceChannel.GuildId).Result as LavaPlayer<LavaTrack>).GetQueue().Clear();
+
         await DestroyPlayerAsync(voiceChannel.GuildId);
     }
     


### PR DESCRIPTION
In Lavalink 4.X.X the queue is managed by Lavalink itself, and becuase of that, the tracks in the queue persist even after the bot leaves the channel, and they stay there until Lavalink is restarted. I found this a little bit annoying at times, so I added a toggle in the config for whether or not the queue should be cleared upon calling Lavanode.LeaveAsync()