### PR TITLE
Fix for Lavalink v4.2.0+

### DIFF
--- a/src/LavaNode.cs
+++ b/src/LavaNode.cs
@@ -1,3 +1,6 @@
+using Discord;
+using Discord.WebSocket;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -6,9 +9,6 @@ using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using System.Web;
-using Discord;
-using Discord.WebSocket;
-using Microsoft.Extensions.Logging;
 using Victoria.Enums;
 using Victoria.Rest;
 using Victoria.Rest.Lavalink;
@@ -600,13 +600,13 @@ public class LavaNode<TLavaPlayer, TLavaTrack> : IAsyncDisposable
             await UpdatePlayerAsync(guildId, updatePayload: new UpdatePlayerPayload(VoiceState: voiceState));
         }
         
-        voiceState = new VoiceState(null, null, currentState.VoiceSessionId);
+        voiceState = new VoiceState(null, null, currentState.VoiceSessionId, currentState.VoiceChannel.Id.ToString());
         _voiceStates[guildId] = voiceState;
     }
     
     private Task OnVoiceServerUpdatedAsync(SocketVoiceServer voiceServer) {
         if (!_voiceStates.TryGetValue(voiceServer.Guild.Id, out var voiceState)) {
-            voiceState = new VoiceState(voiceServer.Token, voiceServer.Endpoint, string.Empty);
+            voiceState = new VoiceState(voiceServer.Token, voiceServer.Endpoint, string.Empty, "");
             _voiceStates.TryAdd(voiceServer.Guild.Id, voiceState);
             return Task.CompletedTask;
         }

--- a/src/LavaNode.cs
+++ b/src/LavaNode.cs
@@ -600,13 +600,13 @@ public class LavaNode<TLavaPlayer, TLavaTrack> : IAsyncDisposable
             await UpdatePlayerAsync(guildId, updatePayload: new UpdatePlayerPayload(VoiceState: voiceState));
         }
         
-        voiceState = new VoiceState(null, null, currentState.VoiceSessionId, currentState.VoiceChannel.Id.ToString());
+        voiceState = new VoiceState(null, null, currentState.VoiceSessionId, $"{currentState.VoiceChannel.Id}");
         _voiceStates[guildId] = voiceState;
     }
     
     private Task OnVoiceServerUpdatedAsync(SocketVoiceServer voiceServer) {
         if (!_voiceStates.TryGetValue(voiceServer.Guild.Id, out var voiceState)) {
-            voiceState = new VoiceState(voiceServer.Token, voiceServer.Endpoint, string.Empty, "");
+            voiceState = new VoiceState(voiceServer.Token, voiceServer.Endpoint, string.Empty, string.Empty);
             _voiceStates.TryAdd(voiceServer.Guild.Id, voiceState);
             return Task.CompletedTask;
         }

--- a/src/Rest/VoiceState.cs
+++ b/src/Rest/VoiceState.cs
@@ -17,4 +17,4 @@ public record struct VoiceState(
     [property: JsonPropertyName("sessionId")]
     string SessionId,
     [property: JsonPropertyName("channelId")]
-    string? ChannelId);
+    string ChannelId);

--- a/src/Rest/VoiceState.cs
+++ b/src/Rest/VoiceState.cs
@@ -8,10 +8,13 @@ namespace Victoria.Rest;
 /// <param name="Token">Discord voice token to authenticate with</param>
 /// <param name="Endpoint">Discord voice endpoint to connect to</param>
 /// <param name="SessionId">Discord voice session id to authenticate with</param>
+/// <param name="ChannelId">Discord voice channel id the bot is connecting to</param>
 public record struct VoiceState(
     [property: JsonPropertyName("token")]
     string Token,
     [property: JsonPropertyName("endpoint")]
     string Endpoint,
     [property: JsonPropertyName("sessionId")]
-    string SessionId);
+    string SessionId,
+    [property: JsonPropertyName("channelId")]
+    string? ChannelId);

--- a/src/Victoria.csproj
+++ b/src/Victoria.csproj
@@ -18,12 +18,12 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<None Include="icon.png" Pack="true" Visible="false" PackagePath=""/>
+		<None Include="icon.png" Pack="true" Visible="false" PackagePath="" />
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Discord.Net.WebSocket" Version="3.15.0" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+		<PackageReference Include="Discord.Net.WebSocket" Version="3.19.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.4" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.4" />
 	</ItemGroup>
 </Project>

--- a/src/Victoria.csproj
+++ b/src/Victoria.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<Version>7.0.5</Version>
+		<Version>7.0.6</Version>
 		<Title>Victoria</Title>
 		<Authors>Yucked; Contributors</Authors>
 		<Copyright>2018 - 2024 Yucked. All rights reserved.</Copyright>


### PR DESCRIPTION
Added ChannelId property to VoiceState struct, which is now required by lavalink.

Also updated dependencies, but that's optional.